### PR TITLE
feat(hero): add initial structure and styling for hero section (part 2)

### DIFF
--- a/src/sections/Hero.tsx
+++ b/src/sections/Hero.tsx
@@ -1,9 +1,14 @@
 import memojiImage from "@/assets/images/memoji-computer.png";
 import Image from "next/image";
 import ArrowDown from '@/assets/icons/arrow-down.svg';
+import grainImage from "@/assets/images/grain.jpg";
 
 export const HeroSection = () => {
-  return <div className="py-32 md:py-48">
+  return <div className="py-32 md:py-48 lg:py-60 relative z-0">
+    <div className="absolute inset-0 -z-30 opacity-5" style={{
+      backgroundImage: `url(${grainImage.src})`,
+    }}></div>
+    <div className="absolute inset-0 size-[620px] border-2 top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full border-emerald-300/5 shadow-[0_0_80px_inset] shadow-emerald-300/5"></div>
     <div className="container">
       <div className="flex flex-col items-center">
         <Image src={memojiImage} className="size-[100px]" alt="Person peeking from behind laptop" />
@@ -12,12 +17,13 @@ export const HeroSection = () => {
           <div className="text-sm font-medium">Available for new projects</div>
         </div>
       </div>
-      
+      <div className="max-w-lg mx-auto">
       <h1 className="font-serif text-3xl md:text-5xl text-center mt-8 tracking-wide">Building Exceptional User Experiences</h1>
-      <p className="mt-4 text-center text-white/60">
+      <p className="mt-4 text-center text-white/60 md:text-lg">
         I specialize in transforming designs into functiona, high-performance web applications. Let's discuss your project.
       </p>
-      <div className="flex flex-col items-center mt-8 gap-4">
+      </div>
+      <div className="flex flex-col md:flex-row justify-center items-center mt-8 gap-4">
         <button className="inline-flex items-center gap-2 border border-white/15 px-6 h-12 rounded-xl">
           <span className="font-semibold">Explore My Work</span>
           <ArrowDown className="size-4" />


### PR DESCRIPTION
### Summary
- Enhanced the `HeroSection` component with additional background visuals and layout improvements.
- Added a subtle grain texture background for depth using the `grain.jpg` image.
- Implemented a centered glowing circular border effect with emerald color for visual emphasis.
- Improved text readability by limiting width (`max-w-lg`) and centering headline and paragraph.
- Adjusted button layout to be responsive — stacking vertically on small screens and horizontally on medium and above.